### PR TITLE
task-45: Баги экрана фильтра по странам и регионам

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/domain/FilterInteractor.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/FilterInteractor.kt
@@ -7,6 +7,7 @@ import ru.practicum.android.diploma.domain.models.Industry
 interface FilterInteractor {
     fun currentFilter(): Filter
     fun newFilter(): Filter
+    fun setCountry(country: Area?)
     fun setArea(area: Area?)
     fun setIndustry(industry: Industry?)
     fun setSalary(salary: String?)

--- a/app/src/main/java/ru/practicum/android/diploma/domain/impl/FilterInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/impl/FilterInteractorImpl.kt
@@ -13,6 +13,10 @@ class FilterInteractorImpl(private val repository: FilterRepository) : FilterInt
     override fun currentFilter(): Filter = currentFilter
     override fun newFilter(): Filter = newFilter
 
+    override fun setCountry(country: Area?) {
+        newFilter = newFilter.copy(country = country)
+    }
+
     override fun setArea(area: Area?) {
         newFilter = newFilter.copy(area = area)
     }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/models/Filter.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/models/Filter.kt
@@ -1,6 +1,7 @@
 package ru.practicum.android.diploma.domain.models
 
 data class Filter(
+    val country: Area? = null,
     val area: Area? = null,
     val industry: Industry? = null,
     val salary: String? = null,

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/country/CountryViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/country/CountryViewModel.kt
@@ -39,6 +39,7 @@ class CountryViewModel(
     }
 
     fun setCountry(country: Area) {
+        filterInteractor.setCountry(country)
         filterInteractor.setArea(country)
         filterInteractor.apply()
     }

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/filter/FilterViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/filter/FilterViewModel.kt
@@ -52,7 +52,9 @@ class FilterViewModel(private val filterInteractor: FilterInteractor, applicatio
     }
 
     fun clearWorkplace() {
+        filterInteractor.setCountry(null)
         filterInteractor.setArea(null)
+        filterInteractor.apply()
     }
 
     fun clearIndustry() {

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/region/RegionViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/region/RegionViewModel.kt
@@ -140,36 +140,36 @@ class RegionViewModel(
     }
 
     fun defineCurrentFilterState() {
+        val filterCountry = filterInteractor.currentFilter().country
         val filterArea = filterInteractor.currentFilter().area
 
-        if (filterArea == null) {
+        if (filterCountry == null) {
             filterState.postValue(WorkplaceState.NothingIsPicked)
         } else {
-            if (filterArea.parentId.isNullOrEmpty()) {
-                filterState.postValue(WorkplaceState.CountryIsPicked(filterArea))
+            if (filterArea?.parentId.isNullOrEmpty()) {
+                filterState.postValue(WorkplaceState.CountryIsPicked(filterCountry))
             } else {
-                viewModelScope.launch {
-                    val country = loadCountryByRegion(filterArea)
-                    filterState.postValue(WorkplaceState.CountryAndRegionIsPicked(country, filterArea))
-                }
+                filterState.postValue(
+                    WorkplaceState.CountryAndRegionIsPicked(
+                        filterCountry, filterArea!!
+                    )
+                )
             }
         }
-    }
-
-    private suspend fun loadCountryByRegion(region: Area): Area {
-        var newArea: Area = region
-
-        while (!newArea.parentId.isNullOrEmpty()) {
-            dictionariesInteractor.getAreasById(newArea.parentId!!).collect {
-                newArea = (it as Resource.Success).data!!
-            }
-        }
-
-        return newArea
     }
 
     fun setCountryAndRegion(region: Area) {
-        filterInteractor.setArea(region)
-        filterInteractor.apply()
+        if (region.parentId.isNullOrEmpty()) {
+            filterInteractor.setCountry(region)
+            filterInteractor.setArea(region)
+            filterInteractor.apply()
+        } else if (filterInteractor.currentFilter().country != null) {
+            filterInteractor.setArea(region)
+            filterInteractor.apply()
+        } else {
+            filterInteractor.setCountry(null)
+            filterInteractor.setArea(region)
+            filterInteractor.apply()
+        }
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/region/RegionViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/region/RegionViewModel.kt
@@ -150,9 +150,7 @@ class RegionViewModel(
                 filterState.postValue(WorkplaceState.CountryIsPicked(filterCountry))
             } else {
                 filterState.postValue(
-                    WorkplaceState.CountryAndRegionIsPicked(
-                        filterCountry, filterArea!!
-                    )
+                    WorkplaceState.CountryAndRegionIsPicked(filterCountry, filterArea!!)
                 )
             }
         }

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/workplace/WorkplaceViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/workplace/WorkplaceViewModel.kt
@@ -28,9 +28,7 @@ class WorkplaceViewModel(
                 filterInteractor.setCountry(country)
                 filterInteractor.apply()
                 workplaceStateLiveData.postValue(
-                    WorkplaceState.CountryAndRegionIsPicked(
-                        country, filterArea
-                    )
+                    WorkplaceState.CountryAndRegionIsPicked(country, filterArea)
                 )
             }
         } else if (filterCountry == null) {
@@ -40,9 +38,7 @@ class WorkplaceViewModel(
                 workplaceStateLiveData.postValue(WorkplaceState.CountryIsPicked(filterCountry))
             } else {
                 workplaceStateLiveData.postValue(
-                    WorkplaceState.CountryAndRegionIsPicked(
-                        filterCountry, filterArea!!
-                    )
+                    WorkplaceState.CountryAndRegionIsPicked(filterCountry, filterArea!!)
                 )
             }
         }

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/workplace/WorkplaceViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/workplace/WorkplaceViewModel.kt
@@ -19,18 +19,31 @@ class WorkplaceViewModel(
     fun getWorkplaceStateLiveData(): LiveData<WorkplaceState> = workplaceStateLiveData
 
     fun loadFilter() {
+        val filterCountry = filterInteractor.currentFilter().country
         val filterArea = filterInteractor.currentFilter().area
 
-        if (filterArea == null) {
+        if (filterCountry == null && filterArea != null) {
+            viewModelScope.launch {
+                val country = loadCountryByRegion(filterArea)
+                filterInteractor.setCountry(country)
+                filterInteractor.apply()
+                workplaceStateLiveData.postValue(
+                    WorkplaceState.CountryAndRegionIsPicked(
+                        country, filterArea
+                    )
+                )
+            }
+        } else if (filterCountry == null) {
             workplaceStateLiveData.postValue(WorkplaceState.NothingIsPicked)
         } else {
-            if (filterArea.parentId.isNullOrEmpty()) {
-                workplaceStateLiveData.postValue(WorkplaceState.CountryIsPicked(filterArea))
+            if (filterArea?.parentId.isNullOrEmpty()) {
+                workplaceStateLiveData.postValue(WorkplaceState.CountryIsPicked(filterCountry))
             } else {
-                viewModelScope.launch {
-                    val country = loadCountryByRegion(filterArea)
-                    workplaceStateLiveData.postValue(WorkplaceState.CountryAndRegionIsPicked(country, filterArea))
-                }
+                workplaceStateLiveData.postValue(
+                    WorkplaceState.CountryAndRegionIsPicked(
+                        filterCountry, filterArea!!
+                    )
+                )
             }
         }
     }
@@ -40,7 +53,15 @@ class WorkplaceViewModel(
 
         while (!newArea.parentId.isNullOrEmpty()) {
             dictionariesInteractor.getAreasById(newArea.parentId!!).collect {
-                newArea = (it as Resource.Success).data!!
+                when (it) {
+                    is Resource.Success -> {
+                        newArea = it.data!!
+                    }
+
+                    is Resource.Error -> {
+                        newArea = region
+                    }
+                }
             }
         }
 
@@ -61,6 +82,7 @@ class WorkplaceViewModel(
             workplaceStateLiveData.value is WorkplaceState.CountryAndRegionIsPicked
         ) {
             workplaceStateLiveData.postValue(WorkplaceState.NothingIsPicked)
+            filterInteractor.setCountry(null)
             filterInteractor.setArea(null)
             filterInteractor.apply()
         }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/country/CountryFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/country/CountryFragment.kt
@@ -89,7 +89,7 @@ class CountryFragment : Fragment() {
         binding.errorImage.isVisible = true
         binding.errorText.isVisible = true
 
-        binding.errorImage.setImageResource(R.drawable.error_image)
-        binding.errorText.text = getString(R.string.server_error)
+        binding.errorImage.setImageResource(R.drawable.empty_areas_list)
+        binding.errorText.text = getString(R.string.unable_to_get_list)
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
@@ -144,7 +144,7 @@ class FilterFragment : Fragment() {
     }
 
     private fun filterScreen(filter: Filter) {
-        binding.workPlaceValue.setText(filter.area?.name)
+        showWorkplace(filter)
         binding.industryValue.setText(filter.industry?.name)
         binding.salaryValue.setText(filter.salary)
         binding.salaryIsRequiredCheck.isChecked = filter.onlyWithSalary
@@ -156,6 +156,22 @@ class FilterFragment : Fragment() {
             binding.salaryFrame.defaultHintTextColor = hintColorStates().first
         } else {
             binding.salaryFrame.defaultHintTextColor = hintColorStates().second
+        }
+    }
+
+    private fun showWorkplace(filter: Filter) {
+        if (filter.country == null) {
+            binding.workPlaceValue.setText(getString(R.string.empty_string))
+        } else if (filter.area?.parentId.isNullOrEmpty()) {
+            binding.workPlaceValue.setText(filter.country.name)
+        } else {
+            binding.workPlaceValue.setText(
+                String.format(
+                    getString(R.string.country_and_region_template),
+                    filter.country.name,
+                    filter.area?.name
+                )
+            )
         }
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/ui/region/RegionFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/region/RegionFragment.kt
@@ -149,8 +149,8 @@ class RegionFragment : Fragment() {
         binding.errorImage.isVisible = true
         binding.errorText.isVisible = true
 
-        binding.errorImage.setImageResource(R.drawable.error_image)
-        binding.errorText.text = getString(R.string.server_error)
+        binding.errorImage.setImageResource(R.drawable.empty_areas_list)
+        binding.errorText.text = getString(R.string.unable_to_get_list)
     }
 
     private fun showNoRegion() {

--- a/app/src/main/java/ru/practicum/android/diploma/ui/workplace/WorkplaceFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/workplace/WorkplaceFragment.kt
@@ -41,10 +41,6 @@ class WorkplaceFragment : Fragment() {
             findNavController().navigate(R.id.action_workplace_fragment_to_region_fragment)
         }
 
-        binding.actionIconCountry.setOnClickListener {
-            workplaceViewModel.deleteCountry()
-        }
-
         binding.actionIconRegion.setOnClickListener {
             workplaceViewModel.deleteRegion()
         }
@@ -87,7 +83,10 @@ class WorkplaceFragment : Fragment() {
         binding.countryTitle.isVisible = true
 
         binding.actionIconCountry.setImageResource(R.drawable.close_icon)
-        binding.actionIconCountry.isEnabled = true
+
+        binding.actionIconCountry.setOnClickListener {
+            workplaceViewModel.deleteCountry()
+        }
 
         binding.countryName.text = country
     }
@@ -98,7 +97,10 @@ class WorkplaceFragment : Fragment() {
         binding.countryTitle.isVisible = false
 
         binding.actionIconCountry.setImageResource(R.drawable.arrow_forward)
-        binding.actionIconCountry.isEnabled = false
+
+        binding.actionIconCountry.setOnClickListener {
+            findNavController().navigate(R.id.action_workplace_fragment_to_country_fragment)
+        }
     }
 
     private fun showRegion(region: String) {
@@ -107,7 +109,10 @@ class WorkplaceFragment : Fragment() {
         binding.regionTitle.isVisible = true
 
         binding.actionIconRegion.setImageResource(R.drawable.close_icon)
-        binding.actionIconRegion.isEnabled = true
+
+        binding.actionIconRegion.setOnClickListener {
+            workplaceViewModel.deleteRegion()
+        }
 
         binding.regionName.text = region
     }
@@ -118,6 +123,9 @@ class WorkplaceFragment : Fragment() {
         binding.regionTitle.isVisible = false
 
         binding.actionIconRegion.setImageResource(R.drawable.arrow_forward)
-        binding.actionIconRegion.isEnabled = false
+
+        binding.actionIconRegion.setOnClickListener {
+            findNavController().navigate(R.id.action_workplace_fragment_to_region_fragment)
+        }
     }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -73,4 +73,6 @@
     <string name="salary_expected"> Ожидаемая зарплата</string>
     <string name="save">Применить</string>
     <string name="reset">Сбросить</string>
+
+    <string name="country_and_region_template">%s, %s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,4 +80,5 @@
     <string name="save">Применить</string>
     <string name="reset">Сбросить</string>
 
+    <string name="country_and_region_template">%s, %s</string>
 </resources>


### PR DESCRIPTION
1. Теперь на общем экране фильтров при выбранных стране и регионе отображаются оба
2. Пофиксил краш при переходе на экран выбора региона при отсутствии интернета
3. Исправил отображение ошибки об отсутствии интернета (Изображение и текст ошибки)
4. Теперь стрелка (правая иконка) на экране выбора места работы нажимается
5. Теперь при очистке региона на главном экране фильтров они очищаются и внутри экрана выбора страны и региона

Теперь в фильтре и в SharedPref есть country, но на фильтрацию это не влияет, т.к. все еще остался area