### PR TITLE
Task 48: Исправление багов на экране фильтрации

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         <activity
             android:name=".ui.root.RootActivity"
             android:exported="true"
-            android:windowSoftInputMode="adjustNothing"
+            android:windowSoftInputMode="stateHidden"
+            android:configChanges="orientation|screenSize|keyboardHidden"
             android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/ru/practicum/android/diploma/di/InteractorModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/InteractorModule.kt
@@ -36,7 +36,7 @@ val interactorModule = module {
         )
     }
 
-    single<FilterInteractor> {
+    factory<FilterInteractor> {
         FilterInteractorImpl(
             repository = get(),
         )

--- a/app/src/main/java/ru/practicum/android/diploma/domain/FilterInteractor.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/FilterInteractor.kt
@@ -14,4 +14,5 @@ interface FilterInteractor {
     fun setOnlyWithSalary(onlyWithSalary: Boolean)
     fun apply()
     fun flushFilters()
+    fun resetCurrentFilter()
 }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/impl/FilterInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/impl/FilterInteractorImpl.kt
@@ -14,31 +14,31 @@ class FilterInteractorImpl(private val repository: FilterRepository) : FilterInt
     override fun appliedFilter(): Filter = repository.loadAppliedFilter()
 
     override fun setCountry(country: Area?) {
-        currentFilter= repository.loadFilter()
+        currentFilter = repository.loadFilter()
         currentFilter = currentFilter.copy(country = country)
         saveCurrentFilter()
     }
 
     override fun setArea(area: Area?) {
-        currentFilter= repository.loadFilter()
+        currentFilter = repository.loadFilter()
         currentFilter = currentFilter.copy(area = area)
         saveCurrentFilter()
     }
 
     override fun setIndustry(industry: Industry?) {
-        currentFilter= repository.loadFilter()
+        currentFilter = repository.loadFilter()
         currentFilter = currentFilter.copy(industry = industry)
         saveCurrentFilter()
     }
 
     override fun setSalary(salary: String?) {
-        currentFilter= repository.loadFilter()
+        currentFilter = repository.loadFilter()
         currentFilter = currentFilter.copy(salary = salary)
         saveCurrentFilter()
     }
 
     override fun setOnlyWithSalary(onlyWithSalary: Boolean) {
-        currentFilter= repository.loadFilter()
+        currentFilter = repository.loadFilter()
         currentFilter = currentFilter.copy(onlyWithSalary = onlyWithSalary)
         saveCurrentFilter()
     }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/impl/FilterInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/impl/FilterInteractorImpl.kt
@@ -10,30 +10,35 @@ class FilterInteractorImpl(private val repository: FilterRepository) : FilterInt
     private var currentFilter: Filter = repository.loadFilter()
     private var appliedFilter: Filter = repository.loadAppliedFilter()
 
-    override fun currentFilter(): Filter = currentFilter
-    override fun appliedFilter(): Filter = appliedFilter
+    override fun currentFilter(): Filter = repository.loadFilter()
+    override fun appliedFilter(): Filter = repository.loadAppliedFilter()
 
     override fun setCountry(country: Area?) {
+        currentFilter= repository.loadFilter()
         currentFilter = currentFilter.copy(country = country)
         saveCurrentFilter()
     }
 
     override fun setArea(area: Area?) {
+        currentFilter= repository.loadFilter()
         currentFilter = currentFilter.copy(area = area)
         saveCurrentFilter()
     }
 
     override fun setIndustry(industry: Industry?) {
+        currentFilter= repository.loadFilter()
         currentFilter = currentFilter.copy(industry = industry)
         saveCurrentFilter()
     }
 
     override fun setSalary(salary: String?) {
+        currentFilter= repository.loadFilter()
         currentFilter = currentFilter.copy(salary = salary)
         saveCurrentFilter()
     }
 
     override fun setOnlyWithSalary(onlyWithSalary: Boolean) {
+        currentFilter= repository.loadFilter()
         currentFilter = currentFilter.copy(onlyWithSalary = onlyWithSalary)
         saveCurrentFilter()
     }
@@ -43,10 +48,13 @@ class FilterInteractorImpl(private val repository: FilterRepository) : FilterInt
     }
 
     private fun saveAppliedFilter() {
+        appliedFilter = repository.loadFilter()
         repository.saveAppliedFilter(appliedFilter)
     }
 
     override fun apply() {
+        currentFilter = repository.loadFilter()
+        appliedFilter = repository.loadAppliedFilter()
         appliedFilter = currentFilter
         repository.saveAppliedFilter(appliedFilter)
     }
@@ -60,5 +68,6 @@ class FilterInteractorImpl(private val repository: FilterRepository) : FilterInt
 
     override fun resetCurrentFilter() {
         currentFilter = Filter()
+        saveCurrentFilter()
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/impl/FilterInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/impl/FilterInteractorImpl.kt
@@ -57,4 +57,8 @@ class FilterInteractorImpl(private val repository: FilterRepository) : FilterInt
         saveCurrentFilter()
         saveAppliedFilter()
     }
+
+    override fun resetCurrentFilter() {
+        currentFilter = Filter()
+    }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/filter/FilterState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/filter/FilterState.kt
@@ -5,6 +5,7 @@ import ru.practicum.android.diploma.domain.models.Filter
 sealed interface FilterState {
     data object Empty : FilterState
     data class Filled(
-        val filter: Filter
+        val filter: Filter,
+        val isFilterChanged: Boolean
     ) : FilterState
 }

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/filter/FilterViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/filter/FilterViewModel.kt
@@ -32,7 +32,7 @@ class FilterViewModel(private val filterInteractor: FilterInteractor, applicatio
     }
 
     fun clearFilter() {
-        filterInteractor.flushFilters()
+        filterInteractor.resetCurrentFilter()
         currentFilter = filterInteractor.currentFilter()
         postCurrentFilter()
     }
@@ -75,6 +75,8 @@ class FilterViewModel(private val filterInteractor: FilterInteractor, applicatio
         currentFilter = filterInteractor.currentFilter()
         postCurrentFilter()
     }
+
+    fun checkFilterIsApplied() = filterInteractor.appliedFilter() == currentFilter
 
     fun currentFilterIsEmpty() = currentFilter == Filter()
 }

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/filter/FilterViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/filter/FilterViewModel.kt
@@ -21,7 +21,13 @@ class FilterViewModel(private val filterInteractor: FilterInteractor, applicatio
         if (currentFilter == Filter()) {
             stateLiveData.postValue(FilterState.Empty)
         } else {
-            stateLiveData.postValue(FilterState.Filled(currentFilter))
+            val appliedFilter = filterInteractor.appliedFilter()
+            if (appliedFilter == currentFilter) {
+                stateLiveData.postValue(FilterState.Filled(currentFilter, false))
+            } else {
+                stateLiveData.postValue(FilterState.Filled(currentFilter, true))
+            }
+
         }
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/search/SearchViewModel.kt
@@ -38,6 +38,8 @@ class SearchViewModel(
     fun observeShowToast(): LiveData<String> = showToast
     fun searchDebounce(changedText: String) {
         if (latestSearchText != changedText) {
+            filterInteractor.apply()
+            appliedFilter = filterInteractor.appliedFilter()
             latestSearchText = changedText
             vacancySearchDebounce(changedText)
         }

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/search/SearchViewModel.kt
@@ -168,7 +168,7 @@ class SearchViewModel(
             currentPage = 0
             vacanciesList.clear()
             latestSearchText?.let { searchText ->
-                searchRequest(searchText, currentPage)
+                searchVacancies(searchText)
             }
         }
     }

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/search/SearchViewModel.kt
@@ -171,6 +171,13 @@ class SearchViewModel(
 
     fun hasFilter() = filterInteractor.currentFilter() != Filter()
 
+    fun clearSearchRequest() {
+        latestSearchText = null
+        currentPage = 0
+        vacanciesList.clear()
+        renderState(SearchState.Default)
+    }
+
     companion object {
         private const val SEARCH_DEBOUNCE_DELAY = 2000L
         private const val PER_PAGE_SIZE = 20

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/search/SearchViewModel.kt
@@ -45,10 +45,6 @@ class SearchViewModel(
         }
     }
 
-//    init {
-//        checkFilters()
-//    }
-
     // Функция для пагинации
     private fun searchVacancies(searchText: String) {
         if (this.currentPage == maxPage) {

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/search/SearchViewModel.kt
@@ -21,7 +21,7 @@ class SearchViewModel(
     private val filterInteractor: FilterInteractor,
     application: Application
 ) : AndroidViewModel(application) {
-    private var appliedFilter: Filter = filterInteractor.appliedFilter()
+    private var appliedFilter: Filter = Filter()
     private var isNextPageLoading: Boolean = false
     private var currentPage: Int = 0
     private var maxPage: Int? = null
@@ -39,7 +39,6 @@ class SearchViewModel(
     fun searchDebounce(changedText: String) {
         if (latestSearchText != changedText) {
             filterInteractor.apply()
-            appliedFilter = filterInteractor.appliedFilter()
             latestSearchText = changedText
             vacancySearchDebounce(changedText)
         }
@@ -64,6 +63,7 @@ class SearchViewModel(
     private fun searchRequest(searchText: String, currentPage: Int) {
         if (searchText.isNotEmpty()) {
             viewModelScope.launch {
+                appliedFilter = filterInteractor.appliedFilter()
                 vacanciesInteractor.searchVacancies(
                     searchText,
                     appliedFilter,

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
@@ -125,11 +125,11 @@ class FilterFragment : Fragment() {
     private fun render(state: FilterState) {
         when (state) {
             FilterState.Empty -> emptyScreen()
-            is FilterState.Filled -> filterScreen(state.filter)
+            is FilterState.Filled -> filterScreen(state.filter, state.isFilterChanged)
         }
     }
 
-    private fun filterScreen(filter: Filter) {
+    private fun filterScreen(filter: Filter, isFilterChanged: Boolean) {
         showWorkplace(filter)
         binding.industryValue.setText(filter.industry?.name)
         binding.salaryIsRequiredCheck.isChecked = filter.onlyWithSalary
@@ -145,6 +145,7 @@ class FilterFragment : Fragment() {
             binding.salaryFrame.defaultHintTextColor = hintColorStates().second
         }
         binding.resetButton.isVisible = true
+        binding.saveButton.isVisible = isFilterChanged
     }
 
     private fun showWorkplace(filter: Filter) {

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
@@ -149,7 +149,8 @@ class FilterFragment : Fragment() {
 
     private fun showWorkplace(filter: Filter) {
         if (filter.country == null) {
-            binding.workPlaceValue.setText(getString(R.string.empty_string))
+            binding.workPlaceValue.text = null
+            binding.workPlace.defaultHintTextColor = setGrayColor()
         } else if (filter.area?.parentId.isNullOrEmpty()) {
             binding.workPlaceValue.setText(filter.country.name)
         } else {
@@ -187,6 +188,7 @@ class FilterFragment : Fragment() {
     }
 
     private fun fillIndustry() {
+        binding.industry.defaultHintTextColor = setGrayColor()
         if (binding.industryValue.text.toString().isNotEmpty()) {
             binding.industry.setEndIconDrawable(R.drawable.close_icon)
             binding.industry.defaultHintTextColor = setHintOnValueColor()

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
@@ -102,8 +102,7 @@ class FilterFragment : Fragment() {
         binding.resetButton.setOnClickListener {
             viewModel.clearFilter()
             inputText = getString(R.string.empty_string)
-            binding.resetButton.isVisible = false
-            binding.saveButton.isVisible = true
+            renderConfirmButtons()
         }
 
         binding.salaryIsRequiredCheck.setOnClickListener {

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
@@ -22,7 +22,7 @@ import ru.practicum.android.diploma.presentation.filter.FilterState
 import ru.practicum.android.diploma.presentation.filter.FilterViewModel
 
 class FilterFragment : Fragment() {
-    private var inputText: String? = ""
+    private var inputText: String? = null
     private var textWatcher: TextWatcher? = null
     private var _binding: FragmentFilterBinding? = null
     private val binding
@@ -83,7 +83,7 @@ class FilterFragment : Fragment() {
             }
 
             override fun afterTextChanged(s: Editable?) {
-                if( inputText != s.toString()) {
+                if (inputText != s.toString()) {
                     viewModel.setSalary(s.toString())
                     renderConfirmButtons()
                 }
@@ -101,7 +101,7 @@ class FilterFragment : Fragment() {
         }
         binding.resetButton.setOnClickListener {
             viewModel.clearFilter()
-            inputText = ""
+            inputText = getString(R.string.empty_string)
             binding.resetButton.isVisible = false
             binding.saveButton.isVisible = true
         }
@@ -118,8 +118,8 @@ class FilterFragment : Fragment() {
     }
 
     private fun renderConfirmButtons() {
-        binding.saveButton.isVisible = !viewModel.currentFilterIsEmpty()
-        binding.resetButton.isVisible = binding.saveButton.isVisible
+        binding.resetButton.isVisible = !viewModel.currentFilterIsEmpty()
+        binding.saveButton.isVisible = !viewModel.checkFilterIsApplied()
     }
 
     private fun render(state: FilterState) {
@@ -144,7 +144,7 @@ class FilterFragment : Fragment() {
             binding.salaryValue.setText(filter.salary)
             binding.salaryFrame.defaultHintTextColor = hintColorStates().second
         }
-        binding.resetButton.isVisible = true
+        renderConfirmButtons()
         binding.saveButton.isVisible = isFilterChanged
     }
 
@@ -201,6 +201,7 @@ class FilterFragment : Fragment() {
                 binding.industry.setEndIconDrawable(R.drawable.arrow_forward)
                 binding.industry.defaultHintTextColor = setGrayColor()
                 binding.industry.setEndIconOnClickListener {
+                    renderConfirmButtons()
                     findNavController().navigate(R.id.action_filter_fragment_to_industry_fragment)
                 }
             }
@@ -214,8 +215,7 @@ class FilterFragment : Fragment() {
     }
 
     private fun emptyScreen() {
-        binding.resetButton.isVisible = false
-        binding.saveButton.isVisible = false
+        renderConfirmButtons()
         binding.workPlaceValue.setText(getString(R.string.empty_string))
         binding.industryValue.setText(getString(R.string.empty_string))
         binding.salaryValue.setText(getString(R.string.empty_string))

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
@@ -83,8 +83,10 @@ class FilterFragment : Fragment() {
             }
 
             override fun afterTextChanged(s: Editable?) {
-                viewModel.setSalary(s.toString())
-                renderConfirmButtons()
+                if( inputText != s.toString()) {
+                    viewModel.setSalary(s.toString())
+                    renderConfirmButtons()
+                }
             }
         }
 

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/FilterFragment.kt
@@ -166,6 +166,7 @@ class FilterFragment : Fragment() {
     }
 
     private fun fillWorkPlace() {
+        binding.workPlace.defaultHintTextColor = setGrayColor()
         if (binding.workPlaceValue.text.toString().isNotEmpty()) {
             binding.workPlace.defaultHintTextColor = setHintOnValueColor()
             binding.workPlace.setEndIconDrawable(R.drawable.close_icon)
@@ -221,6 +222,8 @@ class FilterFragment : Fragment() {
         binding.salaryIsRequiredCheck.isChecked = false
         binding.workPlace.setEndIconDrawable(R.drawable.arrow_forward)
         binding.industry.setEndIconDrawable(R.drawable.arrow_forward)
+        binding.industry.defaultHintTextColor = setGrayColor()
+        binding.workPlace.defaultHintTextColor = setGrayColor()
     }
 
     private fun hintColorStates(): Triple<ColorStateList, ColorStateList, ColorStateList> {

--- a/app/src/main/java/ru/practicum/android/diploma/ui/search/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/search/SearchFragment.kt
@@ -93,6 +93,7 @@ class SearchFragment : Fragment() {
                     viewModel.searchDebounce(changedText = s.toString())
                 } else {
                     binding.searchFrame.setEndIconDrawable(R.drawable.search_icon)
+                    viewModel.clearSearchRequest()
                 }
             }
         }

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -19,31 +19,33 @@
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/top_app_bar"
             style="@style/AndroidDiploma.ToolBar"
-            app:title="@string/vacancy_search_title"
-            app:menu="@menu/top_search_app_bar">
+            app:menu="@menu/top_search_app_bar"
+            app:title="@string/vacancy_search_title">
 
 
         </com.google.android.material.appbar.MaterialToolbar>
 
     </com.google.android.material.appbar.AppBarLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/search_frame"
-            style="@style/AndroidDiploma.EditTextStyleBoxed"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/search_height"
-            app:layout_constraintTop_toBottomOf="@id/search_title">
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/search_frame"
+        style="@style/AndroidDiploma.EditTextStyleBoxed"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/search_height"
+        android:focusable="false"
+        android:focusableInTouchMode="false"
+        app:layout_constraintTop_toBottomOf="@id/search_title">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/input_edit_text"
             style="@style/AndroidDiploma.EditTextStyleBoxed.Input"
             android:layout_width="match_parent"
             android:layout_height="@dimen/search_height"
-            android:padding="@dimen/size_zero"
             android:layout_marginHorizontal="@dimen/size_xxl"
-            android:hint="@string/enter_request"/>
+            android:hint="@string/enter_request"
+            android:padding="@dimen/size_zero" />
 
-        </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
 
     <LinearLayout
         android:id="@+id/search_main_field"
@@ -87,10 +89,10 @@
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="@dimen/size_zero"
-        app:layout_constraintTop_toBottomOf="@id/search_frame"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/search_frame"
         app:layout_constraintVertical_weight="1"
         tools:itemCount="20"
         tools:layout_editor_absoluteX="@dimen/size_zero"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -34,8 +34,6 @@
         <item name="android:fontFamily">@font/ys_display_regular</item>
         <item name="android:hint">@dimen/size_s</item>
         <item name="android:layout_gravity">center_vertical</item>
-        <item name="android:imeOptions">actionDone</item>
-        <item name="android:inputType">text</item>
         <item name="android:maxLines">1</item>
         <item name="android:singleLine">true</item>
         <item name="android:textAllCaps">false</item>
@@ -60,6 +58,19 @@
         <item name="endIconMode">custom</item>
         <item name="android:textSize">16sp</item>
         <item name="android:fontWeight">400</item>
+    </style>
+
+
+    <style name="AndroidDiploma.EditTextStyleBoxed.Input">
+        <item name="android:textColor">@color/black_universal</item>
+        <item name="android:textColorHint">?attr/text_hint_color</item>
+        <item name="android:background" />
+        <item name="android:textSize">16sp</item>
+        <item name="android:fontWeight">400</item>
+        <item name="android:inputType">text</item>
+        <item name="android:imeOptions">actionDone</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:ellipsize">end</item>
     </style>
 
     <style name="AndroidDiploma.TextStyleFilter">
@@ -90,16 +101,6 @@
         <item name="android:ellipsize">end</item>
     </style>
 
-    <style name="AndroidDiploma.EditTextStyleBoxed.Input">
-        <item name="android:textColor">@color/black_universal</item>
-        <item name="android:textColorHint">?attr/text_hint_color</item>
-        <item name="android:background" />
-        <item name="android:textSize">16sp</item>
-        <item name="android:fontWeight">400</item>
-        <item name="android:inputType">text</item>
-        <item name="android:maxLines">1</item>
-        <item name="android:ellipsize">end</item>
-    </style>
 
     <style name="AndroidDiploma.SalaryInputTextStyle">
         <item name="boxBackgroundColor">?attr/edit_text_color</item>


### PR DESCRIPTION
ЗП теперь не пропадает при переходах между экранами
Настройка фильтрации: поля место работы и Отрасль - черные, если их очистить, перейти на экран выбора отрасли и модели а затем вернуться. должны быть серые - исправлено
Настройка фильтрации: кнопка "Применить" должна появляться только когда внесены изменения в фильтр. при запуске экрана ее быть не должно, также можно ее не убирать если очищаем все поля, для того чтоб применить пустой фильтр для поиска - исправлено
КР Поиск Вакансий, настройка фильтрации : Если в приложении есть сохранённые настройки параметров фильтрации, то все поисковые запросы должны выполняться с учётом всех непустых параметров.. В текущей версии при выходе из фильтра кнопкой назад, или при перезапуске приложения - фильтр сохраняется но не применяется к последующим запросам. - исправлено
Поиск вакансий: при новом поиске с примененным фильтром - при загрузке второй страницы прогружается лоудер на весь экран - исправлено
